### PR TITLE
S-107220 Automate token create

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ There are two ways to install the plugin into Release.
 
 **Install plugin via commandline**
 
-Update the Release server details in `[publisher]-release-[target]-integration/.xebialabs/config.yaml`
+Update the Release server details in `release-integration-template-python/.xebialabs/config.yaml`
 
 Run the command for Unix / macOS:
 ```commandline

--- a/README.md
+++ b/README.md
@@ -69,9 +69,9 @@ build.bat
 
 The above command builds the zip, creates the container image, and then pushes the image to the configured registry.
 
-`build.bat --zip` Builds only the zip.
+`build.bat --zip` Builds the zip.
 
-`build.bat --image` Builds only creates the container image, and then pushes the image to the configured registry.
+`build.bat --image` Creates the container image, and then pushes the image to the configured registry.
 
 ### Install plugin into Release
 

--- a/README.md
+++ b/README.md
@@ -67,7 +67,11 @@ sh build.sh
 build.bat 
 ```
 
-This builds the zip and the container image and pushes the image to the configured registry.
+The above command builds the zip, creates the container image, and then pushes the image to the configured registry.
+
+`build.bat --zip` Builds only the zip.
+
+`build.bat --image` Builds only creates the container image, and then pushes the image to the configured registry.
 
 ### Install plugin into Release
 
@@ -86,7 +90,7 @@ Run the command for Windows:
 ```commandline
 build.bat --upload 
 ```
-The above command builds the zip and image and uploads the zip to the release server.
+The above command builds the zip, creates the container image, pushes the image to the configured registry, and uploads the zip to the release server.
 
 **Install plugin via Release server UI**
 

--- a/dev-environment/.env
+++ b/dev-environment/.env
@@ -1,6 +1,2 @@
 ## Release server settings
 RELEASE_RUNNER_RELEASE_URL=http://localhost:5516
-
-## Runner env variables
-RUNNER_PROJECT_NAME=release-remote-runner
-RUNNER_PROJECT_VERSION=23.3.0

--- a/dev-environment/digitalai-release-remote-runner/Dockerfile
+++ b/dev-environment/digitalai-release-remote-runner/Dockerfile
@@ -1,4 +1,5 @@
-FROM xebialabs/release-remote-runner:23.3.0
+# todo change image to official
+FROM xlr-registry:5050/digitalai/release-runner:0.2.0
 
 RUN apk add --no-cache curl jq
 

--- a/dev-environment/digitalai-release-remote-runner/Dockerfile
+++ b/dev-environment/digitalai-release-remote-runner/Dockerfile
@@ -1,4 +1,4 @@
-FROM xebialabs/release-remote-runner:23.3.0
+FROM xebialabsunsupported/release-remote-runner:24.1.0-beta.3
 
 RUN apk add --no-cache curl jq
 

--- a/dev-environment/digitalai-release-remote-runner/spin-remote-runner.sh
+++ b/dev-environment/digitalai-release-remote-runner/spin-remote-runner.sh
@@ -6,7 +6,7 @@ WAIT_INTERVAL=5
 start_time=$(date +%s)
 end_time=$((start_time + MAX_WAIT_SECONDS))
 
-api_url="http://localhost:5516/tokens/users/remote-runner"
+api_url="http://localhost:5516/api/v1/personal-access-tokens"
 unique_id=$(date +%s%N | md5sum | awk '{print $1}')
 
 while true; do
@@ -17,7 +17,7 @@ while true; do
         exit 1
     fi
 
-    response=$(curl -s -i -X POST -u admin:admin -H "Content-Type: application/json;charset=UTF-8" -d '{"tokenNote": "'$unique_id'"}' $api_url)
+    response=$(curl -s -i -X POST -u admin:admin -H "Content-Type: application/json;charset=UTF-8" -d '{"tokenNote": "'$unique_id'", "globalPermissions": ["runner#registration"]}' $api_url)
 
     if [ $? -ne 0 ]; then
         echo "Fetching token failed - probably still initializing... retrying soon"
@@ -40,4 +40,4 @@ while true; do
     sleep $WAIT_INTERVAL
 done
 
-exec /app/release-remote-runner --profiles docker
+exec /app/release-runner --profiles docker

--- a/dev-environment/digitalai-release-setup/.gitignore
+++ b/dev-environment/digitalai-release-setup/.gitignore
@@ -1,1 +1,0 @@
-secrets.xlvals

--- a/dev-environment/digitalai-release-setup/instance-configuration.yaml
+++ b/dev-environment/digitalai-release-setup/instance-configuration.yaml
@@ -9,29 +9,3 @@ spec:
     loginMessage: |-
       Welcome to the Digital.ai Release SDK Environment!
       Use this server to test integrations plugins
-
----
-apiVersion: xl-release/v1
-kind: Users
-spec:
-  - username: remote-runner
-    password: !value password
-    name: Remote Runner
-    enabled: true
-
----
-apiVersion: xl-release/v1
-kind: Roles
-spec:
-  - name: Runners
-    principals:
-      - remote-runner
-
----
-apiVersion: xl-release/v1
-kind: Permissions
-spec:
-  - global:
-      - role: Runners
-        permissions:
-          - runner#registration

--- a/dev-environment/digitalai-release-setup/secrets.xlvals
+++ b/dev-environment/digitalai-release-setup/secrets.xlvals
@@ -1,1 +1,0 @@
-password=r3mote-runn3R

--- a/dev-environment/digitalai-release/Dockerfile
+++ b/dev-environment/digitalai-release/Dockerfile
@@ -1,4 +1,4 @@
-FROM xebialabs/xl-release:23.3
+FROM xebialabsunsupported/xl-release:24.1.0-beta.3
 
 # Install license
 # COPY default-conf/xl-release-license.lic /opt/xebialabs/xl-release-server/default-conf/

--- a/dev-environment/digitalai-release/Dockerfile
+++ b/dev-environment/digitalai-release/Dockerfile
@@ -1,4 +1,5 @@
-FROM xebialabs/xl-release:23.3
+# todo change image to official
+FROM xebialabsunsupported/xl-release:24.1
 
 # Install license
 # COPY default-conf/xl-release-license.lic /opt/xebialabs/xl-release-server/default-conf/

--- a/dev-environment/docker-compose.yaml
+++ b/dev-environment/docker-compose.yaml
@@ -24,8 +24,6 @@ services:
       - digitalai-release-setup
     environment:
       - RELEASE_RUNNER_RELEASE_URL=${RELEASE_RUNNER_RELEASE_URL}
-      - PROJECT_NAME=${RUNNER_PROJECT_NAME}
-      - VERSION=${RUNNER_PROJECT_VERSION}
     network_mode: host
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-digitalai-release-sdk == 23.3.0
+digitalai-release-sdk == 24.1.0rc1
 requests >= 2.28.1

--- a/resources/type-definitions.yaml
+++ b/resources/type-definitions.yaml
@@ -22,6 +22,19 @@ types:
       iconLocation: test.png
       taskColor: "#667385"
 
+  # All scripts in this project extend the BaseScript.
+  containerExamples.BaseScript:
+    extends: xlrelease.RemoteScriptExecution
+    virtual: true
+
+    hidden-properties:
+      image:
+        default: "@registry.url@/@registry.org@/@project.name@:@project.version@"
+        transient: true
+
+    output-properties:
+      commandResponse:
+        kind: map_string_string
 
   # Simple example task.
   # The Python SDK will look for a corresponding Python class called 'Hello'
@@ -81,3 +94,15 @@ types:
         default: https://dummyjson.com
         description: A Dummy JSON server
         required: true
+
+    hidden-properties:
+      testConnectionScript: containerExamples.TestConnection
+
+  # Example test connection script
+  containerExamples.TestConnection:
+    extends: containerExamples.BaseScript
+
+    input-properties:
+      server:
+        kind: ci
+        referenced-type: containerExamples.Server

--- a/src/test_connection.py
+++ b/src/test_connection.py
@@ -1,0 +1,26 @@
+import requests
+from digitalai.release.integration import BaseTask
+
+
+class TestConnection(BaseTask):
+    """
+        Testing connection to the remote server
+    """
+    def execute(self) -> None:
+
+        try:
+            # Process input
+            server = self.input_properties['server']
+            server_url = server['url'].strip("/")
+            auth = (server['username'], server['password'])
+
+            # Make request
+            response = requests.get(server_url, auth=auth)
+            response.raise_for_status()
+
+            # Process result
+            result = {"success": True, "output": "Connection success"}
+        except Exception as e:
+            result = {"success": False, "output": str(e)}
+        finally:
+            self.set_output_property("commandResponse", result)


### PR DESCRIPTION
Use scoped tokens for enabling Runner access.
Avoid creating Runner user and permissions.
After official images for Release and Runner are published, change them in Dockerfiles.