### PR TITLE
S-107220 Automate token create

### DIFF
--- a/dev-environment/.env
+++ b/dev-environment/.env
@@ -1,6 +1,2 @@
 ## Release server settings
 RELEASE_RUNNER_RELEASE_URL=http://localhost:5516
-
-## Runner env variables
-RUNNER_PROJECT_NAME=release-remote-runner
-RUNNER_PROJECT_VERSION=23.3.0

--- a/dev-environment/digitalai-release-remote-runner/Dockerfile
+++ b/dev-environment/digitalai-release-remote-runner/Dockerfile
@@ -1,4 +1,4 @@
-FROM xebialabsunsupported/release-remote-runner:24.1.0-beta.3
+FROM xebialabsunsupported/release-remote-runner:24.1.0-410.113
 
 RUN apk add --no-cache curl jq
 

--- a/dev-environment/digitalai-release-remote-runner/Dockerfile
+++ b/dev-environment/digitalai-release-remote-runner/Dockerfile
@@ -1,6 +1,8 @@
-FROM xebialabsunsupported/release-remote-runner:24.1.0-410.113
+FROM xebialabsunsupported/release-runner:24.1.0-411.1033
 
-RUN apk add --no-cache curl jq
+USER root
+
+RUN apt update && apt install -y curl jq dos2unix
 
 COPY spin-remote-runner.sh /spin-remote-runner.sh
 RUN dos2unix /spin-remote-runner.sh && chmod +x /spin-remote-runner.sh

--- a/dev-environment/digitalai-release-remote-runner/Dockerfile
+++ b/dev-environment/digitalai-release-remote-runner/Dockerfile
@@ -1,4 +1,5 @@
-FROM xebialabs/release-remote-runner:23.3.0
+# todo change image to official
+FROM xlr-registry:5050/digitalai/release-runner:0.2.0
 
 RUN apk add --no-cache curl jq
 

--- a/dev-environment/digitalai-release-remote-runner/Dockerfile
+++ b/dev-environment/digitalai-release-remote-runner/Dockerfile
@@ -1,4 +1,4 @@
-FROM xebialabsunsupported/release-runner:24.1.0-411.1033
+FROM xebialabsunsupported/release-runner:24.1.0-412.113
 
 USER root
 

--- a/dev-environment/digitalai-release-remote-runner/spin-remote-runner.sh
+++ b/dev-environment/digitalai-release-remote-runner/spin-remote-runner.sh
@@ -6,7 +6,7 @@ WAIT_INTERVAL=5
 start_time=$(date +%s)
 end_time=$((start_time + MAX_WAIT_SECONDS))
 
-api_url="http://localhost:5516/tokens/users/remote-runner"
+api_url="http://localhost:5516/api/v1/personal-access-tokens"
 unique_id=$(date +%s%N | md5sum | awk '{print $1}')
 
 while true; do
@@ -17,7 +17,7 @@ while true; do
         exit 1
     fi
 
-    response=$(curl -s -i -X POST -u admin:admin -H "Content-Type: application/json;charset=UTF-8" -d '{"tokenNote": "'$unique_id'"}' $api_url)
+    response=$(curl -s -i -X POST -u admin:admin -H "Content-Type: application/json;charset=UTF-8" -d '{"tokenNote": "'$unique_id'", "globalPermissions": ["runner#registration"]}' $api_url)
 
     if [ $? -ne 0 ]; then
         echo "Fetching token failed - probably still initializing... retrying soon"
@@ -40,4 +40,4 @@ while true; do
     sleep $WAIT_INTERVAL
 done
 
-exec /app/release-remote-runner --profiles docker
+exec /app/release-runner --profiles docker

--- a/dev-environment/digitalai-release-setup/.gitignore
+++ b/dev-environment/digitalai-release-setup/.gitignore
@@ -1,1 +1,0 @@
-secrets.xlvals

--- a/dev-environment/digitalai-release-setup/instance-configuration.yaml
+++ b/dev-environment/digitalai-release-setup/instance-configuration.yaml
@@ -9,29 +9,3 @@ spec:
     loginMessage: |-
       Welcome to the Digital.ai Release SDK Environment!
       Use this server to test integrations plugins
-
----
-apiVersion: xl-release/v1
-kind: Users
-spec:
-  - username: remote-runner
-    password: !value password
-    name: Remote Runner
-    enabled: true
-
----
-apiVersion: xl-release/v1
-kind: Roles
-spec:
-  - name: Runners
-    principals:
-      - remote-runner
-
----
-apiVersion: xl-release/v1
-kind: Permissions
-spec:
-  - global:
-      - role: Runners
-        permissions:
-          - runner#registration

--- a/dev-environment/digitalai-release-setup/secrets.xlvals
+++ b/dev-environment/digitalai-release-setup/secrets.xlvals
@@ -1,1 +1,0 @@
-password=r3mote-runn3R

--- a/dev-environment/digitalai-release/Dockerfile
+++ b/dev-environment/digitalai-release/Dockerfile
@@ -1,4 +1,4 @@
-FROM xebialabsunsupported/xl-release:24.1.0-beta.3
+FROM xebialabsunsupported/xl-release:24.1
 
 # Install license
 # COPY default-conf/xl-release-license.lic /opt/xebialabs/xl-release-server/default-conf/

--- a/dev-environment/digitalai-release/Dockerfile
+++ b/dev-environment/digitalai-release/Dockerfile
@@ -1,4 +1,5 @@
-FROM xebialabs/xl-release:23.3
+# todo change image to official
+FROM xebialabsunsupported/xl-release:24.1
 
 # Install license
 # COPY default-conf/xl-release-license.lic /opt/xebialabs/xl-release-server/default-conf/

--- a/dev-environment/docker-compose.yaml
+++ b/dev-environment/docker-compose.yaml
@@ -24,8 +24,6 @@ services:
       - digitalai-release-setup
     environment:
       - RELEASE_RUNNER_RELEASE_URL=${RELEASE_RUNNER_RELEASE_URL}
-      - PROJECT_NAME=${RUNNER_PROJECT_NAME}
-      - VERSION=${RUNNER_PROJECT_VERSION}
     network_mode: host
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock


### PR DESCRIPTION
Use scoped tokens for enabling Runner access.
Avoid creating Runner user and permissions.
After official images for Release and Runner are published, change them in Dockerfiles.