### PR TITLE
Fix unsupported Docker image for Docker Registry UI

### DIFF
--- a/dev-environment/docker-compose.yaml
+++ b/dev-environment/docker-compose.yaml
@@ -39,15 +39,20 @@ services:
       - .:/var/lib/registry
 
   container-registry-ui:
-    image: parabuzzle/craneoperator:latest
+    image: joxit/docker-registry-ui:latest
     ports:
       - "8086:80"
     environment:
-      - REGISTRY_HOST=container-registry
-      - REGISTRY_PORT=5000
-      - REGISTRY_PROTOCOL=http
-      - REGISTRY_ALLOW_DELETE=true
-      - SSL_VERIFY=false
-      - TITLE=Digital.ai Release Docker Registry
+      - SINGLE_REGISTRY=true
+      - REGISTRY_TITLE=Digital.ai Release Docker Registry UI
+      - DELETE_IMAGES=true
+      - SHOW_CONTENT_DIGEST=true
+      - NGINX_PROXY_PASS_URL=http://container-registry:5000
+      - SHOW_CATALOG_NB_TAGS=true
+      - CATALOG_MIN_BRANCHES=1
+      - CATALOG_MAX_BRANCHES=1
+      - TAGLIST_PAGE_SIZE=100
+      - REGISTRY_SECURED=false
+      - CATALOG_ELEMENTS_LIMIT=1000
     depends_on:
       - container-registry


### PR DESCRIPTION
Current Docker compose file fails to build:

```
❯ cd dev-environment
❯ docker compose up -d --build
WARN[0000] /.../release-integration-template-python/dev-environment/docker-compose.yaml: `version` is obsolete
[+] Running 0/1
 ⠋ container-registry-ui Pulling                                                                                                 2.1s
[DEPRECATION NOTICE] Docker Image Format v1 and Docker Image manifest version 2, schema 1 support is disabled by default and will be removed in an upcoming release. Suggest the author of docker.io/parabuzzle/craneoperator:latest to upgrade the image to the OCI Format or Docker Image manifest v2, schema 2. More information at https://docs.docker.com/go/deprecated-image-specs/
```

This PR replacing outdated Docker Image parabuzzle/craneoperator for Docker Registry UI with other working alternative